### PR TITLE
Add prompt helper UI (keep-prompt toggle, guidance, char count)

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -30,6 +30,7 @@ function Home() {
   const [showQuickPrompts, setShowQuickPrompts] = useState(false);
   const [fullscreenImage, setFullscreenImage] = useState(null);
   const [favorites, setFavorites] = useState([]);
+  const promptLength = prompt.trim().length;
 
   useEffect(() => {
     const loadData = async () => {
@@ -251,6 +252,15 @@ function Home() {
                     >
                       <FiSettings className="w-5 h-5" />
                     </button>
+                    <label className="flex items-center gap-2 text-xs sm:text-sm text-gray-300">
+                      <input
+                        type="checkbox"
+                        checked={keepPrompt}
+                        onChange={(e) => setKeepPrompt(e.target.checked)}
+                        className="h-4 w-4 rounded border-white/30 bg-white/10 text-purple-500 focus:ring-2 focus:ring-purple-400"
+                      />
+                      Zadrži prompt nakon generiranja
+                    </label>
                   </div>
                 </div>
 
@@ -310,6 +320,15 @@ function Home() {
                   rows="4"
                   disabled={isLoading}
                 />
+                <div className="flex flex-wrap items-center justify-between gap-2 text-xs sm:text-sm text-gray-400 mt-2">
+                  <span>
+                    Savet: navedite stil, atmosferu i detalje (npr. svetlo,
+                    boje, kompoziciju).
+                  </span>
+                  <span className="text-gray-300">
+                    {promptLength} karaktera
+                  </span>
+                </div>
               </div>
 
               {/* Generate Button */}


### PR DESCRIPTION
### Motivation
- Improve the prompt authoring experience by making it easier to keep a prompt after generation and by giving users immediate guidance and feedback about prompt length.

### Description
- Introduce a `promptLength` derived value (`prompt.trim().length`) and display it in the UI under the prompt textarea.
- Add a `Zadrži prompt nakon generiranja` checkbox bound to the existing `keepPrompt` state next to the settings button to allow keeping the prompt after generation.
- Add a short guidance text below the textarea instructing users to include style, atmosphere and details.
- Changes are contained in `src/pages/Home.jsx` and are purely UI additions with layout and small class tweaks.

### Testing
- Started the dev server with `npm run dev` and it launched successfully (Vite ready).  
- Captured a full-page screenshot using Playwright (`artifacts/home-improvements.png`) to validate the UI render, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a10d5f80c832c8ed5990a76f23dc8)